### PR TITLE
ci: Node.js 20 非推奨対応のためアクションを最新版に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -66,7 +66,7 @@ jobs:
           DATABASE_URL: "file:./ci-test.db"
 
       - name: Restore Next.js build cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx', '**/*.css') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
           allowed-endpoints: >

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: block
           allowed-endpoints: >


### PR DESCRIPTION
## 概要

GitHub Actions ランナーで Node.js 20 アクションが非推奨となり、**2026年6月16日以降は Node.js 24 がデフォルト強制**、9月16日にはランナーから削除されます。CIログで警告が出ていた2アクションを Node.js 24 対応の最新リリースへ更新します。

## 変更内容

| アクション | 旧 | 新 |
|---|---|---|
| `actions/cache` | v4 (`5a3ec84e`) | **v5.0.5** (`27d5ce7f`) |
| `step-security/harden-runner` | v2.15.1 (`58077d3c`) | **v2.19.4** (`9af89fc7`) — ci / codeql / deploy / scorecard の全4ワークフロー |

## 互換性

- `actions/cache` v5: Node 24 ランタイム化 + 新キャッシュバックエンド(v2 API)。`path` / `key` / `restore-keys` の入力は変更なし。v5.0.1 で Node 24 の punycode 非推奨問題も修正済み。GitHub ホストランナーのため最低ランナーバージョン要件(2.327.1)も自動で充足
- `harden-runner` v2.19.4: 同一メジャー(v2)で `egress-policy` / `allowed-endpoints` の入力は不変
- 従来どおり全アクションをコミットSHAで固定(プロジェクト規約)

🤖 Generated with [Claude Code](https://claude.com/claude-code)