### PR TITLE
fix: postcss の XSS 脆弱性 (GHSA-qx2v-qp2m-jg93) を解消

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7211,34 +7211,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "eslint-config-next": "^16.2.9",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## 概要

`npm audit` で残存していた moderate 2件（postcss の XSS, GHSA-qx2v-qp2m-jg93）を解消します。

Next.js 16.2.9 がバンドルする `postcss@8.4.31`（`<8.5.10` で脆弱）が原因でした。

## 対応

- `package.json` に `overrides` を追加し、postcss を `^8.5.10` に固定
- Next 配下の postcss も既存トップレベルと同じ `8.5.15` に dedup され、`npm audit` が **0 件** に

```json
"overrides": {
  "postcss": "^8.5.10"
}
```

### 不採用とした方法
`npm audit fix --force` は Next.js 9 系へのダウングレード（破壊的変更）になるため不採用。overrides によるパッチ適用で互換性を維持。

## 検証

- ✅ `npm audit` → `found 0 vulnerabilities`
- ✅ `npm ls postcss --all` → 全て 8.5.15（next も deduped）
- ✅ `npm ci` → 同期エラーなし・再現性確認
- ✅ `npx tsc --noEmit` → エラーなし
- ✅ `npm run build` → Compiled successfully（Tailwind CSS パイプライン含む）

## 影響範囲

依存解決のみ。アプリケーションコードの変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)