### PR TITLE
fix: CSP を nonce 方式へ刷新（ログイン復旧）+ ヘッダ/順序ハードニング

### DIFF
--- a/app/api/attendance-export/route.ts
+++ b/app/api/attendance-export/route.ts
@@ -25,14 +25,6 @@ export async function GET(request: NextRequest) {
     const multiDates = searchParams.get("dates");
     const guildId = searchParams.get("guildId");
 
-    // Validate guildId format (Discord Snowflake: 17-20 digits)
-    if (guildId && !/^\d{17,20}$/.test(guildId)) {
-        return NextResponse.json(
-            { error: "Invalid guildId format" },
-            { status: 400 }
-        );
-    }
-
     // Get API key from Authorization header (preferred) or query param (deprecated)
     const authHeader = request.headers.get("Authorization");
     let apiKey: string | null = null;
@@ -65,6 +57,16 @@ export async function GET(request: NextRequest) {
         return NextResponse.json(
             { error: "Rate limit exceeded" },
             { status: 429, headers }
+        );
+    }
+
+    // Validate guildId format (Discord Snowflake: 17-20 digits).
+    // Done after authentication so unauthenticated callers can't probe
+    // input-validation behavior.
+    if (guildId && !/^\d{17,20}$/.test(guildId)) {
+        return NextResponse.json(
+            { error: "Invalid guildId format" },
+            { status: 400 }
         );
     }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,6 +22,12 @@ export const metadata: Metadata = {
   },
 };
 
+// Nonce-based CSP (see proxy.ts) requires dynamic rendering: a per-request
+// nonce only exists at request time, so statically pre-rendered pages would
+// ship nonce-less inline scripts that the CSP then blocks. Forcing dynamic
+// rendering at the root applies the nonce to every route.
+export const dynamic = "force-dynamic";
+
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,8 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  // Don't advertise the framework via the X-Powered-By response header.
+  poweredByHeader: false,
   images: {
     remotePatterns: [
       {

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,14 +3,26 @@ import { NextRequest, NextResponse } from "next/server";
 // Must match SESSION_COOKIE_NAME in app/lib/session.ts (set by PR security/auth-session-hardening)
 const SESSION_COOKIE_NAME = "__Host-session";
 
-export function proxy(request: NextRequest) {
-    const { pathname } = request.nextUrl;
-
-    const isDev = process.env.NODE_ENV === "development";
-
-    const cspHeader = [
+/**
+ * Build the Content-Security-Policy header value for a given nonce.
+ *
+ * script-src uses a per-request nonce plus 'strict-dynamic' so that Next.js's
+ * own inline bootstrap/hydration scripts execute (they carry the matching
+ * nonce), while any attacker-injected inline script is still blocked. This
+ * replaces the previous `script-src 'self'`, which blocked Next.js's inline
+ * scripts entirely and broke client-side hydration.
+ *
+ * In development React relies on `eval` for richer error overlays, so
+ * 'unsafe-eval' is required there only (never in production).
+ *
+ * style-src intentionally keeps 'unsafe-inline': Next.js/next-font and
+ * Tailwind emit inline styles that are not all nonce-tagged, and inline
+ * styles are not an XSS execution vector the way scripts are.
+ */
+function buildCsp(nonce: string, isDev: boolean): string {
+    return [
         "default-src 'self'",
-        isDev ? "script-src 'self' 'unsafe-eval'" : "script-src 'self'",
+        `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ""}`,
         "style-src 'self' 'unsafe-inline'",
         "img-src 'self' https://cdn.discordapp.com data:",
         "font-src 'self'",
@@ -19,6 +31,18 @@ export function proxy(request: NextRequest) {
         "base-uri 'self'",
         "object-src 'none'",
     ].join("; ");
+}
+
+export function proxy(request: NextRequest) {
+    const { pathname } = request.nextUrl;
+
+    const isDev = process.env.NODE_ENV === "development";
+
+    // A fresh, unpredictable nonce per request. Next.js reads it back from the
+    // Content-Security-Policy request header during SSR and applies it to the
+    // scripts it generates.
+    const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+    const cspHeader = buildCsp(nonce, isDev);
 
     // Auth gate for protected web pages: redirect to login
     if (pathname.startsWith("/staff") || pathname.startsWith("/ticket")) {
@@ -41,7 +65,16 @@ export function proxy(request: NextRequest) {
         }
     }
 
-    const response = NextResponse.next();
+    // Propagate the nonce (and the CSP it lives in) to the request so Next.js
+    // can stamp the nonce onto its framework/inline scripts during rendering,
+    // then mirror the same CSP onto the response.
+    const requestHeaders = new Headers(request.headers);
+    requestHeaders.set("x-nonce", nonce);
+    requestHeaders.set("Content-Security-Policy", cspHeader);
+
+    const response = NextResponse.next({
+        request: { headers: requestHeaders },
+    });
     response.headers.set("Content-Security-Policy", cspHeader);
 
     return response;
@@ -49,6 +82,15 @@ export function proxy(request: NextRequest) {
 
 export const config = {
     matcher: [
-        "/((?!_next/static|_next/image|favicon.ico).*)",
+        // Run on everything except static assets. Skip prefetch requests so a
+        // per-request nonce is never baked into a cached prefetch payload
+        // (recommended by the Next.js CSP guide).
+        {
+            source: "/((?!_next/static|_next/image|favicon.ico).*)",
+            missing: [
+                { type: "header", key: "next-router-prefetch" },
+                { type: "header", key: "purpose", value: "prefetch" },
+            ],
+        },
     ],
 };


### PR DESCRIPTION
## 背景

本番サイトを Playwright で動的監査した結果、**CSP の `script-src 'self'` が Next.js のインラインブートストラップ／RSC ストリーミングスクリプトを丸ごとブロックし、React のハイドレーションが起きずログインボタンが無反応**（=Webログイン不能）になっていました。あわせて軽微なヘッダ/順序の指摘も修正します。

## 変更点

### 1. CSP を nonce 方式へ（最優先・機能復旧 + CSP維持）
`proxy.ts` をリクエストごとの nonce 発行方式に刷新（[Next.js 公式 CSP ガイド](https://nextjs.org/docs/app/guides/content-security-policy)準拠）。
- `script-src 'self' 'nonce-<n>' 'strict-dynamic'`（dev のみ `'unsafe-eval'`）
- nonce と CSP を **request header** に伝播 → Next.js が自前スクリプトに nonce を自動付与
- レスポンスにも同じ CSP を付与
- `matcher` に **prefetch 除外**を追加（per-request nonce がキャッシュされる問題を回避）
- 既存の認証ゲート（`/staff`・`/ticket` リダイレクト、`/api/scan` 401）は**維持**
- `style-src` は `'unsafe-inline'` を維持（next/font・Tailwind のインラインスタイル互換のため。スタイルは XSS 実行ベクタではない）

### 2. 全ページ動的レンダリング化
nonce 方式は動的レンダリング必須（静的ページは build 時に nonce を持てない）。root layout に `export const dynamic = 'force-dynamic'` を設定。全 HTML ルートが `ƒ (Dynamic)` に移行。

### 3. `poweredByHeader: false`（L-B）
`X-Powered-By: Next.js` の露出を抑止。

### 4. Export API の認証→検証の順序（L-C）
`attendance-export` の `guildId` 形式検証を **API キー認証の後**へ移動。未認証者がバリデーション挙動を観測できないように。

## 検証
- ✅ `npx tsc --noEmit` / `npm run build` 成功（全 HTML ルートが動的化）
- ⏳ マージ後、本番を Playwright で再検証（ログインボタン動作・nonce 付き CSP・ハイドレーション）

## 補足: L-A（ヘッダ重複/XFO 矛盾）は対象外
`X-Frame-Options: DENY, SAMEORIGIN` 等の重複値はリポジトリ内に発生源が無く（grep 済み）、前段の Cloudflare/リバースプロキシ由来のためコードでは修正不可。別途エッジ側の設定変更が必要（本文末で詳細報告）。なお `frame-ancestors 'none'` が CSP 側で常に効いておりクリックジャッキング保護は担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)