### PR TITLE
feat(deploy): AOP enforce 化 (ssl_verify_client on) — Phase 2

### DIFF
--- a/deploy/nginx/ajmun.conf
+++ b/deploy/nginx/ajmun.conf
@@ -30,15 +30,14 @@ server {
     # （Cloudflare の WAF / Access バイパス）を遮断する。共有証明書ではないため
     # 「あなたのゾーン由来」であることまで保証する。
     #
-    # 安全な有効化は2段階（順序を誤るとサイト停止）:
-    #   1) Cloudflare に leaf 証明書 + 鍵をアップロードし、Zone-level AOP を On
-    #      （SSL/TLS → Origin Server → Authenticated Origin Pulls → Zone-level）
-    #      Cloudflare が当該クライアント証明書を提示し始める。
-    #   2) 上記を確認した「後で」 ssl_verify_client を optional → on に変更し、
-    #      有効な証明書が無い接続を拒否する。
-    #   ※ 1 の前に on にすると Cloudflare の正規リクエストも拒否され停止する。
+    # 前提（設定済み）: Cloudflare に leaf 証明書 + 鍵をアップロードし、
+    # Zone-level AOP を On にしてある（Cloudflare が当該証明書を提示する）。
+    # その状態で `on` にすることで、有効な証明書が無い接続（=非自ゾーンの
+    # オリジン直アクセス）を拒否する。
+    # ※ Cloudflare 側 AOP を無効化する場合は、先にこれを optional/off へ戻すこと
+    #   （順序を誤ると Cloudflare の正規リクエストも拒否され停止する）。
     ssl_client_certificate /etc/nginx/ssl/aop-origin-ca.pem;
-    ssl_verify_client optional;
+    ssl_verify_client on;
 
     location / {
         proxy_pass http://127.0.0.1:3000;


### PR DESCRIPTION
## 概要
Zone-level Authenticated Origin Pulls の最終段階。Cloudflare への leaf 証明書アップロード + Zone-level AOP 有効化が完了し、オリジンが Cloudflare 提示の証明書を独自 CA で**検証成功**することを確認したため、`ssl_verify_client` を `optional` → **`on`** に切替えて遮断します。

## 効果
有効な証明書を提示しない接続（= オリジン IP への直接アクセス＝ Cloudflare の WAF/Access バイパス）を **400 で拒否**。

## 実機検証済み（適用後に確認）
- ✅ Cloudflare 経由: `200 OK`（維持。`X-AOP-Status: SUCCESS`）
- ✅ オリジン直 (`https://<origin-ip>/ -H Host`): `400 Bad Request`（証明書なしを拒否）
- ✅ 他サブドメイン `ajmundb.re4lity.com` (302) / `ssh.re4lity.com` (200): **影響なし**

## ロールバック手順（将来 CF 側 AOP を無効化する場合）
先に `ssl_verify_client` を `optional` か `off` に戻してから Cloudflare の Zone-level AOP を無効化する（順序を誤ると停止）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)