### PR TITLE
feat(deploy): ajmundb (Prisma Studio) に vhost 個別 AOP を追加

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Shell scripts and nginx config must use LF so they run on Linux hosts
 # regardless of contributors' core.autocrlf settings.
 *.sh text eol=lf
-deploy/nginx/ajmun.conf text eol=lf
+deploy/nginx/*.conf text eol=lf
 deploy/nginx/*.pem text eol=lf
 docker-entrypoint.sh text eol=lf

--- a/deploy/nginx/install-nginx-config.sh
+++ b/deploy/nginx/install-nginx-config.sh
@@ -1,54 +1,64 @@
 #!/bin/sh
-# Install the repo-managed nginx assets for ajmun37 and reload nginx safely.
+# Install the repo-managed nginx assets and reload nginx safely.
 #
 # Installs:
 #   - deploy/nginx/aop-origin-ca.pem -> /etc/nginx/ssl/ (AOP client-cert verification)
-#   - deploy/nginx/ajmun.conf        -> /etc/nginx/conf.d/
+#   - deploy/nginx/*.conf (see CONFS)  -> /etc/nginx/conf.d/
 #
 # Runs as host root (invoked from deploy.yml via a privileged container that
 # enters the host namespaces with nsenter, because the deploy user has no
 # passwordless sudo for nginx but is in the docker group).
 #
 # Behavior:
-#   - no-op if both files already match what is installed
-#   - otherwise: back up current config -> copy new -> `nginx -t` -> reload
-#   - if `nginx -t` fails, restore the backup and exit non-zero (fails deploy)
+#   - no-op if every managed file already matches what is installed
+#   - otherwise: back up current -> copy new -> `nginx -t` -> reload
+#   - if `nginx -t` fails, restore the backups and exit non-zero (fails deploy)
 set -eu
 
 SRC_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-SRC_CONF="$SRC_DIR/ajmun.conf"
-SRC_CA="$SRC_DIR/aop-origin-ca.pem"
-DST_CONF=/etc/nginx/conf.d/ajmun.conf
-DST_CA=/etc/nginx/ssl/aop-origin-ca.pem
+DST_SSL=/etc/nginx/ssl
+DST_CONF_DIR=/etc/nginx/conf.d
 
-if [ ! -f "$SRC_CONF" ]; then
-    echo "ERROR: source config not found: $SRC_CONF" >&2
-    exit 1
-fi
+SRC_CA="$SRC_DIR/aop-origin-ca.pem"
+DST_CA="$DST_SSL/aop-origin-ca.pem"
+
+# nginx vhosts managed from the repo. Only Cloudflare-proxied vhosts that
+# enforce AOP belong here; ssh.re4lity.com is DNS-only and must NOT be managed
+# with AOP, so it is intentionally excluded.
+CONFS="ajmun.conf prisma-studio.conf"
 
 changed=0
+backups=""
 
 # AOP origin CA (public cert; verifies the client cert Cloudflare presents)
 if [ -f "$SRC_CA" ] && { [ ! -f "$DST_CA" ] || ! cmp -s "$SRC_CA" "$DST_CA"; }; then
-    mkdir -p /etc/nginx/ssl
+    mkdir -p "$DST_SSL"
     cp "$SRC_CA" "$DST_CA"
     chmod 644 "$DST_CA"
     echo "installed CA: $DST_CA"
     changed=1
 fi
 
-# Site config
-BAK=""
-if [ ! -f "$DST_CONF" ] || ! cmp -s "$SRC_CONF" "$DST_CONF"; then
-    if [ -f "$DST_CONF" ]; then
-        BAK="$DST_CONF.bak.$(date +%F-%H%M%S)"
-        cp "$DST_CONF" "$BAK"
-        echo "backup created: $BAK"
+# Site configs
+for c in $CONFS; do
+    src="$SRC_DIR/$c"
+    dst="$DST_CONF_DIR/$c"
+    if [ ! -f "$src" ]; then
+        echo "ERROR: source config not found: $src" >&2
+        exit 1
     fi
-    cp "$SRC_CONF" "$DST_CONF"
-    echo "installed config: $DST_CONF"
-    changed=1
-fi
+    if [ ! -f "$dst" ] || ! cmp -s "$src" "$dst"; then
+        if [ -f "$dst" ]; then
+            b="$dst.bak.$(date +%F-%H%M%S)"
+            cp "$dst" "$b"
+            backups="$backups $b"
+            echo "backup created: $b"
+        fi
+        cp "$src" "$dst"
+        echo "installed config: $dst"
+        changed=1
+    fi
+done
 
 if [ "$changed" -eq 0 ]; then
     echo "nginx assets unchanged — nothing to do"
@@ -60,10 +70,11 @@ if nginx -t; then
     echo "RESULT: nginx reloaded"
 else
     echo "RESULT: nginx -t FAILED — rolling back" >&2
-    if [ -n "$BAK" ]; then
-        cp "$BAK" "$DST_CONF"
-        echo "restored config from $BAK" >&2
-    fi
+    for b in $backups; do
+        orig=$(echo "$b" | sed 's/\.bak\.[0-9-]*$//')
+        cp "$b" "$orig"
+        echo "restored $orig" >&2
+    done
     nginx -t >/dev/null 2>&1 && nginx -s reload || true
     exit 1
 fi

--- a/deploy/nginx/prisma-studio.conf
+++ b/deploy/nginx/prisma-studio.conf
@@ -1,0 +1,39 @@
+# ajmundb.re4lity.com — Prisma Studio (DB 管理 UI) の nginx リバースプロキシ
+#
+# このファイルはリポジトリの正本です。deploy/nginx/install-nginx-config.sh が
+# /etc/nginx/conf.d/prisma-studio.conf へ配置し、nginx -t 検証後にリロードします。
+#
+# Prisma Studio は DB 全体への読み書き UI のため、Cloudflare Access に加えて
+# オリジン側でも Authenticated Origin Pulls (mTLS) を強制し、オリジン IP への
+# 直接アクセス（Cloudflare Access バイパス）を遮断する。ajmun37 と同じ独自 CA を使用。
+
+server {
+    listen 80;
+    server_name ajmundb.re4lity.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name ajmundb.re4lity.com;
+
+    ssl_certificate /etc/nginx/ssl/cloudflare-origin.pem;
+    ssl_certificate_key /etc/nginx/ssl/cloudflare-origin.key;
+
+    # Authenticated Origin Pulls (mTLS, zone-level / 独自証明書) — ajmun37 と共通の CA。
+    # Cloudflare が提示するクライアント証明書を検証し、非 Cloudflare の直接接続を拒否する。
+    # 前提: Cloudflare 側で zone-level AOP が有効（ajmun37 で確認済み・ゾーン全体に適用）。
+    ssl_client_certificate /etc/nginx/ssl/aop-origin-ca.pem;
+    ssl_verify_client on;
+
+    location / {
+        proxy_pass http://127.0.0.1:5555;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## 概要
ブランケットな Cloudflare-IP ファイアウォールは `ssh.re4lity.com`（**DNS only**・独自 Let's Encrypt 証明書の直接公開サービス）を遮断してしまうため不採用とし、**vhost 個別の Authenticated Origin Pulls** に統一します。

`ajmundb.re4lity.com`（Prisma Studio = DB 全アクセス UI）は Cloudflare Access で保護されていますが、**オリジン側に AOP が無く**、オリジン IP 直アクセスで CF Access を迂回できる状態でした。`ajmun37` と同じ独自 CA で AOP を強制します。

## 変更
- `deploy/nginx/prisma-studio.conf`: リポジトリ正本として追加。443 に `ssl_client_certificate aop-origin-ca.pem` + `ssl_verify_client on`。
- `deploy/nginx/install-nginx-config.sh`: 複数 vhost を配置・検証・リロード（`nginx -t` 失敗時は全件ロールバック）。
- `.gitattributes`: `deploy/nginx/*.conf` を LF 固定に一般化。

## 対象範囲
- ✅ ajmun37（既存）/ ajmundb（本 PR）= CF 経由 → AOP 強制
- ❌ ssh.re4lity.com = DNS only（直接公開）→ **AOP 対象外**（触らない）
- ❌ 00-default = 別途検討（SSH レート制限で内容未確認のため本 PR では対象外）

## 検証方針
zone-level AOP はゾーン全体に適用され、Cloudflare は ajmundb にも証明書を提示する（ajmun37 で `X-AOP-Status: SUCCESS` 確認済み）。デプロイ後、外部から:
- オリジン直 `https://<origin-ip>/ -H 'Host: ajmundb.re4lity.com'` → **400**（AOP 拒否）
- ajmun37 / ssh.re4lity.com → 影響なし

を確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)